### PR TITLE
Make simulator config portable and persist setup

### DIFF
--- a/ecosystem/ecosystem/ecosystem.py
+++ b/ecosystem/ecosystem/ecosystem.py
@@ -8,6 +8,10 @@ from ..earth.earth import EarthCondition
 # from ..other.other import autosave_tick, csv_log, save
 
 import string, configparser
+from pathlib import Path
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "config.ini"
 
 s = Composer.the_beginning_of_ecology
 b = Composer.the_second_stage
@@ -35,7 +39,7 @@ class Ecosystem:
     '''
     def __init__(self, earth_status, society):
         config = configparser.ConfigParser()
-        config.read(r"C:\Users\admin\Documents\生態系\ecosystem_simulator\config.ini", encoding="utf-8")
+        config.read(CONFIG_PATH, encoding="utf-8")
         self.config = config["OptimalEarthCondition"]
         '''
         # デフォルトステータス

--- a/ecosystem/environment/global_environment/hazard/hazard.py
+++ b/ecosystem/environment/global_environment/hazard/hazard.py
@@ -1,7 +1,18 @@
+from pathlib import Path
+import configparser
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[4] / "config.ini"
+
+
+def _load_config():
+    parser = configparser.ConfigParser()
+    parser.read(CONFIG_PATH, encoding="utf-8")
+    return parser
+
+
 class Hazard:
-    import configparser
-    config = configparser.ConfigParser()
-    config.read(r"C:\Users\admin\Documents\生態系\ecosystem_simulator\config.ini", encoding="utf-8")
+    _config = _load_config()
 
     # 影響日数
     def __init__(self, days=1, name="Hazard"):
@@ -19,7 +30,8 @@ class Hazard:
 class Drought(Hazard): # 干ばつ
     def __init__(self, days=10, config=None):
         super().__init__(days, name="干ばつ")
-        self.config = config["Drought"]
+        parser = config or _load_config()
+        self.config = parser["Drought"]
 
     def effect(self):
         return (
@@ -31,7 +43,8 @@ class Drought(Hazard): # 干ばつ
 class Flood(Hazard): # 洪水
     def __init__(self, days=10, config=None):
         super().__init__(days, name="洪水")
-        self.config = config["Flood"]
+        parser = config or _load_config()
+        self.config = parser["Flood"]
 
     def effect(self):
         return (
@@ -43,7 +56,8 @@ class Flood(Hazard): # 洪水
 class Wildfire(Hazard): # 山火事
     def __init__(self, days=10, config=None):
         super().__init__(days, name="山火事")
-        self.config = config["Wildfire"]
+        parser = config or _load_config()
+        self.config = parser["Wildfire"]
 
     def effect(self):
         return (
@@ -55,7 +69,8 @@ class Wildfire(Hazard): # 山火事
 class Earthquake(Hazard): # 地震
     def __init__(self, days=10, config=None):
         super().__init__(days, name="地震")
-        self.config = config["Earthquake"]
+        parser = config or _load_config()
+        self.config = parser["Earthquake"]
 
     def effect(self):
         return (

--- a/ecosystem/mainloop/mainloop.py
+++ b/ecosystem/mainloop/mainloop.py
@@ -1,11 +1,22 @@
-import time, psutil, keyboard, subprocess, sys
+import time
+import psutil
+import keyboard
+import subprocess
+import sys
+from pathlib import Path
+
 from ..display.display import display_atmosphere, display_hardware, display_kids, display_status
 from ..other.other import save, autosave_tick, csv_log
 
 import configparser
+
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "config.ini"
+
+
 config = configparser.ConfigParser()
-config.read(r"C:\Users\admin\Documents\生態系\ecosystem_simulator\config.ini", encoding="utf-8")
-compactmode = config["Simulator"]["compact"]
+config.read(CONFIG_PATH, encoding="utf-8")
+compactmode = config["Simulator"].get("compact", "0")
 
 if compactmode == "1":
     from ..display.display_compact import display_status_ecology, display_status_other, display_atmosphere, display_hardware

--- a/main.py
+++ b/main.py
@@ -1,22 +1,27 @@
+from pathlib import Path
+
 from ecosystem.ecosystem.ecosystem import Ecosystem
 from ecosystem.environment.environment import Drought, Flood, Wildfire, Earthquake
 from ecosystem.utils.utils import load_status
 from ecosystem.mainloop.mainloop import run_simulation, run_simulation_compact
 
 import configparser
+
+
+BASE_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = BASE_DIR / "config.ini"
+SAVE_PATH = BASE_DIR / "save.json"
+
+
 config = configparser.ConfigParser()
-config.read(r"C:\Users\admin\Documents\生態系\ecosystem_simulator\config.ini", encoding="utf-8")
-compactmode = config["Simulator"]["compact"]
+config.read(CONFIG_PATH, encoding="utf-8")
+compactmode = config["Simulator"].get("compact", "0")
 
 
 
 if __name__ == "__main__":
-
-    config_ini = configparser.ConfigParser()
-    config_ini.read('config.ini', encoding='utf-8')
-
     # セーブ読み込み
-    status, hazards_data = load_status('save.json')
+    status, hazards_data = load_status(str(SAVE_PATH))
     # インスタンス
     eco = Ecosystem(status, society="2.0")
 
@@ -30,7 +35,7 @@ if __name__ == "__main__":
     for hz in hazards_data:
         cls = name_to_class.get(hz["name"])
         if cls:
-            eco.envsys.add_hazard(cls(days=hz["days"]))
+            eco.envsys.add_hazard(cls(days=hz["days"], config=config))
             
     if compactmode == "1":
         run_simulation_compact(eco)

--- a/shell.py
+++ b/shell.py
@@ -1,11 +1,26 @@
-import art, csv, configparser, subprocess, sys, time, keyboard
+import csv
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import art
+import configparser
+import keyboard
 from rich.console import Console
 from rich.table import Table
 from rich.progress import track
 # for i in track(range(100)):
-#     sleep(0.1)
+#     sleep(0.1)  # デモ用
+
+
+BASE_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = BASE_DIR / "config.ini"
+MAIN_PATH = BASE_DIR / "main.py"
+
 
 config = configparser.ConfigParser()
+config.read(CONFIG_PATH, encoding="utf-8")
 
 
 item = ["窒素", "酸素", "二酸化炭素", "水", "有機物", "無機物",
@@ -102,12 +117,29 @@ Earthquake = {
     "pollution" : 0.0,
 }
 
-Hazards = { 
+Hazards = {
             "Drought": Drought,
             "Flood": Flood,
             "Wildfire": Wildfire,
             "Earthquake": Earthquake
         }
+
+def _load_hazard_defaults():
+    for hazard_name, values in Hazards.items():
+        if hazard_name not in config:
+            continue
+        section = config[hazard_name]
+        for key in values:
+            if key in section:
+                try:
+                    values[key] = float(section[key])
+                except ValueError:
+                    # 不正値は既存のデフォルトを維持する
+                    pass
+
+
+_load_hazard_defaults()
+
 
 console = Console()
 ascii_art = art.text2art("Ecosystem   Simulator")
@@ -120,34 +152,56 @@ def make_savefile(text: str = ""):
     #     sleep(0.01)  # デモ用
     return "セーブファイルを作成しました。続いて設定を行うには'setup()'を実行してください。"
 
-def setting(H, HJ, default):
+def setting(hazard_key, hazard_label, use_default):
+    if use_default:
+        print(f"{hazard_label}の設定をすべてデフォルトで設定しました。")
+        return
 
-    if default == 1:
-        print(f"{HJ}の設定をすべてデフォルトで設定しました。")
+    print("\n必ずfloat型で入力してください。不正な値を入力した場合はデフォルト値になります。")
+    print("デフォルトでよい場合は何も打ち込まずにエンターを押してください。")
+    for resource in item:
+        current = Hazards[hazard_key][resource]
+        raw = input(f"{hazard_label}(default={current}): ")
+        if not raw.strip():
+            continue
+        try:
+            Hazards[hazard_key][resource] = float(raw)
+        except ValueError:
+            print("不正な値が入力されたため、デフォルト値を維持します。")
 
-    else:
-        print("\n必ずfloat型で入力してください。不正な値を入力した場合はデフォルト値になります。")
-        print("デフォルトでよい場合は何も打ち込まずにエンターを押してください。")
-        for i in item:
-            # try:
-            Hazards[H][i] = float(input(f"{HJ}(default={Hazards[H][i]}): "))
-            # except:
-                # pass
+
+def _write_hazard_config():
+    config.read(CONFIG_PATH, encoding="utf-8")
+    for hazard_name, values in Hazards.items():
+        if hazard_name not in config:
+            config[hazard_name] = {}
+        for key, value in values.items():
+            config[hazard_name][key] = str(value)
+    with CONFIG_PATH.open('w', encoding='utf-8') as configfile:
+        config.write(configfile)
     
 def setup():
     print("災害の一日あたりの影響を設定を行います。")
-    default = input("初めに、干ばつの影響を設定します。すべてデフォルトでよい場合は1を打ちエンターを、カスタムする場合は0を打ちエンターを押してください。: ")
-    setting("Drought", "干ばつ", default)
+    config.read(CONFIG_PATH, encoding="utf-8")
+    _load_hazard_defaults()
 
-    default = input("次に、洪水の影響を設定します。すべてデフォルトでよい場合は1を打ちエンターを、カスタムする場合は0を打ちエンターを押してください。: ")
-    setting("Flood", "洪水", default)
+    prompts = (
+        ("Drought", "干ばつ"),
+        ("Flood", "洪水"),
+        ("Wildfire", "山火事"),
+        ("Earthquake", "地震"),
+    )
 
-    default = input("次に、山火事の影響を設定します。すべてデフォルトでよい場合は1を打ちエンターを、カスタムする場合は0を打ちエンターを押してください。: ")
-    setting("Wildfire", "山火事", default)
+    for idx, (key, label) in enumerate(prompts):
+        prefix = "初めに" if idx == 0 else "次に"
+        default = input(
+            f"{prefix}、{label}の影響を設定します。すべてデフォルトでよい場合は1を打ちエンターを、"
+            "カスタムする場合は0を打ちエンターを押してください。: "
+        ).strip()
+        use_default = default == "1"
+        setting(key, label, use_default)
 
-    default = input("次に、地震の影響を設定します。すべてデフォルトでよい場合は1を打ちエンターを、カスタムする場合は0を打ちエンターを押してください。: ")
-    setting("Earthquake", "地震", default)
-
+    _write_hazard_config()
     print("設定が完了しました。")
 
 RED = '\033[31m'
@@ -180,9 +234,9 @@ def check():
         sys.stdout.flush()
     print("コンパクトモードで設定しました" if mode else "通常モードで設定しました")
 
-    config.read("config.ini", encoding="utf-8")
+    config.read(CONFIG_PATH, encoding="utf-8")
     config["Simulator"]["compact"] = str(mode)
-    with open("config.ini", 'w', encoding='utf-8') as configfile:
+    with CONFIG_PATH.open('w', encoding='utf-8') as configfile:
         config.write(configfile)
 
 def help():
@@ -208,13 +262,13 @@ def quit():
     exit()
 
 def start():
-    from os import path
-    import subprocess
-
-    #パターン1 .batファイルを呼び出す
-    runPath = path.join(path.dirname(__file__), 'run.bat')
-    subprocess.Popen(runPath)
-    # subprocess.Popen([sys.executable, "main.py"]); sys.exit()
+    command = [sys.executable, str(MAIN_PATH)]
+    try:
+        subprocess.Popen(command)
+    except FileNotFoundError:
+        print("Pythonの実行ファイルが見つかりませんでした。環境を確認してください。")
+    else:
+        print("メインシミュレーションを別プロセスで起動しました。")
     
 
 def Shell(banner='', namespace={}):


### PR DESCRIPTION
## Summary
- load config.ini via pathlib across shell, main loop, hazards, and ecosystem classes for cross-platform paths
- persist setup() inputs back into config.ini and reuse them as defaults before prompting users
- launch main.py with the active Python interpreter instead of relying on Windows-only run.bat and pass config data to hazard reconstruction

## Testing
- python -m compileall . *(fails: existing indentation error in ecosystem/poorly.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f3deef38832cb0304d9fed238a18